### PR TITLE
Fix loyalty recognition PII leak

### DIFF
--- a/bite/app/Livewire/GuestMenu.php
+++ b/bite/app/Livewire/GuestMenu.php
@@ -44,8 +44,6 @@ class GuestMenu extends Component
 
     public $showWelcomeBack = false;
 
-    public $customerOrderHistory = [];
-
     public $orderError = null;
 
     public $locale = 'en';
@@ -588,7 +586,6 @@ class GuestMenu extends Component
         if (strlen($digits) < 8) {
             $this->recognizedCustomer = null;
             $this->showWelcomeBack = false;
-            $this->customerOrderHistory = [];
 
             return;
         }
@@ -598,28 +595,13 @@ class GuestMenu extends Component
 
         if ($customer) {
             $this->recognizedCustomer = [
-                'name' => $customer->name,
+                'name' => $this->firstNameToken($customer->name),
                 'points' => (int) $customer->points,
-                'visit_count' => (int) $customer->visit_count,
-                'favorites' => $customer->getFavorites(),
             ];
             $this->showWelcomeBack = true;
-
-            // Fetch recent order history
-            $orders = $loyaltyService->getOrderHistory($phone, $this->shop->id, 5);
-            $this->customerOrderHistory = $orders->map(fn ($order) => [
-                'id' => $order->id,
-                'total' => (float) $order->total_amount,
-                'date' => $order->created_at->diffForHumans(),
-                'items' => $order->items->map(fn ($item) => [
-                    'name' => $item->product_name_snapshot_en,
-                    'quantity' => $item->quantity,
-                ])->all(),
-            ])->all();
         } else {
             $this->recognizedCustomer = null;
             $this->showWelcomeBack = false;
-            $this->customerOrderHistory = [];
         }
     }
 
@@ -628,11 +610,11 @@ class GuestMenu extends Component
      */
     public function orderUsual(): void
     {
-        if (! $this->recognizedCustomer || empty($this->recognizedCustomer['favorites'])) {
+        if (! $this->recognizedCustomer) {
             return;
         }
 
-        $this->applyFavorite($this->recognizedCustomer['favorites']);
+        $this->applyFavorite();
     }
 
     public function submitOrder()
@@ -837,7 +819,6 @@ class GuestMenu extends Component
         $this->loyaltyError = null;
         $this->recognizedCustomer = null;
         $this->showWelcomeBack = false;
-        $this->customerOrderHistory = [];
 
         return $this->redirect(route('guest.track', $order->tracking_token), navigate: true);
     }
@@ -865,8 +846,25 @@ class GuestMenu extends Component
         session()->flash('message', __('guest.favorite_saved'));
     }
 
+    public function applyFavorite(): void
+    {
+        $customer = app(LoyaltyService::class)->recognize($this->loyaltyPhone, $this->shop->id);
+        if (! $customer) {
+            session()->flash('message', __('guest.favorite_empty'));
+
+            return;
+        }
+
+        $this->applyFavoriteItems($customer->getFavorites());
+    }
+
     #[On('favorite:apply')]
-    public function applyFavorite($items = [])
+    public function applySavedFavorite($items = []): void
+    {
+        $this->applyFavoriteItems($items);
+    }
+
+    protected function applyFavoriteItems($items = []): void
     {
         $items = collect($items)->filter(fn ($item) => isset($item['id']))->values();
         if ($items->isEmpty()) {
@@ -958,6 +956,11 @@ class GuestMenu extends Component
 
         $this->cart = $newCart;
         session()->flash('message', $loadedMessage);
+    }
+
+    protected function firstNameToken(?string $name): string
+    {
+        return Str::of($name ?? '')->squish()->before(' ')->toString();
     }
 
     /**

--- a/bite/resources/views/livewire/guest-menu.blade.php
+++ b/bite/resources/views/livewire/guest-menu.blade.php
@@ -509,38 +509,14 @@
                                         </p>
                                         <p class="mt-1 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-ink-soft">
                                             {{ $recognizedCustomer['points'] ?? 0 }} {{ __('guest.points_label') }}
-                                            &middot;
-                                            {{ $recognizedCustomer['visit_count'] ?? 0 }} {{ __('guest.visits_label') }}
                                         </p>
                                     </div>
                                 </div>
 
-                                @if(!empty($recognizedCustomer['favorites']))
-                                    <button wire:click="orderUsual" class="btn-secondary mt-3 w-full justify-center !border-crema/40 !bg-crema/10 !text-crema hover:!bg-crema/20">
-                                        {{ __('guest.order_your_usual') }}
-                                    </button>
-                                @endif
+                                <button wire:click="orderUsual" type="button" class="btn-secondary mt-3 w-full justify-center !border-crema/40 !bg-crema/10 !text-crema hover:!bg-crema/20">
+                                    {{ __('guest.order_your_usual') }}
+                                </button>
                             </div>
-
-                            {{-- Recent Order History --}}
-                            @if(!empty($customerOrderHistory))
-                                <div class="mt-3 space-y-2">
-                                    <p class="font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-ink-soft">{{ __('guest.recent_orders') }}</p>
-                                    <div class="divide-y divide-line rounded-lg border border-line bg-panel">
-                                        @foreach($customerOrderHistory as $pastOrder)
-                                            <div class="px-3 py-2">
-                                                <div class="flex items-center justify-between">
-                                                    <p class="font-mono text-[10px] font-semibold uppercase tracking-[0.12em] text-ink-soft">{{ $pastOrder['date'] }}</p>
-                                                    <p class="font-mono text-[10px] font-bold uppercase text-ink"><x-price :amount="$pastOrder['total']" :shop="$shop" /></p>
-                                                </div>
-                                                <p class="mt-1 text-xs text-ink-soft">
-                                                    {{ collect($pastOrder['items'])->map(fn($i) => $i['quantity'] . 'x ' . $i['name'])->join(', ') }}
-                                                </p>
-                                            </div>
-                                        @endforeach
-                                    </div>
-                                </div>
-                            @endif
                         @endif
                     </section>
                 </div>

--- a/bite/tests/Feature/GuestMenuPrivacyTest.php
+++ b/bite/tests/Feature/GuestMenuPrivacyTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\GuestMenu;
+use App\Models\Category;
+use App\Models\LoyaltyCustomer;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Product;
+use App\Models\Shop;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use ReflectionClass;
+use Tests\TestCase;
+
+class GuestMenuPrivacyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_recognize_customer_does_not_expose_order_history(): void
+    {
+        [$shop] = $this->createMenu();
+        $this->createCustomer($shop);
+        $order = Order::forceCreate([
+            'shop_id' => $shop->id,
+            'loyalty_phone' => '99887766',
+            'status' => 'completed',
+            'subtotal_amount' => 7.500,
+            'tax_amount' => 0,
+            'total_amount' => 7.500,
+        ]);
+        OrderItem::create([
+            'order_id' => $order->id,
+            'product_name_snapshot_en' => 'Private Anniversary Cake',
+            'price_snapshot' => 7.500,
+            'quantity' => 1,
+        ]);
+
+        $component = Livewire::test(GuestMenu::class, ['shop' => $shop])
+            ->set('loyaltyPhone', '99887766')
+            ->call('recognizeCustomer');
+
+        $component
+            ->assertSet('recognizedCustomer', ['name' => 'Mohammed', 'points' => 120])
+            ->assertDontSee('Private Anniversary Cake')
+            ->assertDontSee(__('guest.recent_orders'));
+
+        $this->assertFalse((new ReflectionClass(GuestMenu::class))->hasProperty('customerOrderHistory'));
+    }
+
+    public function test_recognize_customer_does_not_expose_favorites(): void
+    {
+        [$shop, $product] = $this->createMenu();
+        $this->createCustomer($shop, [
+            [
+                'id' => $product->id,
+                'name' => 'Secret Wedding Order',
+                'quantity' => 2,
+                'selectedModifiers' => [],
+            ],
+        ]);
+
+        $component = Livewire::test(GuestMenu::class, ['shop' => $shop])
+            ->set('loyaltyPhone', '99887766')
+            ->call('recognizeCustomer');
+
+        $recognizedCustomer = $component->get('recognizedCustomer');
+
+        $this->assertSame(['name' => 'Mohammed', 'points' => 120], $recognizedCustomer);
+        $this->assertArrayNotHasKey('favorites', $recognizedCustomer);
+        $this->assertStringNotContainsString('Secret Wedding Order', json_encode($recognizedCustomer));
+    }
+
+    public function test_recognize_customer_returns_only_first_name_token(): void
+    {
+        [$shop] = $this->createMenu();
+        $this->createCustomer($shop);
+
+        $recognizedCustomer = Livewire::test(GuestMenu::class, ['shop' => $shop])
+            ->set('loyaltyPhone', '99887766')
+            ->call('recognizeCustomer')
+            ->get('recognizedCustomer');
+
+        $this->assertSame('Mohammed', $recognizedCustomer['name']);
+        $this->assertSame(120, $recognizedCustomer['points']);
+        $this->assertArrayNotHasKey('visit_count', $recognizedCustomer);
+    }
+
+    public function test_order_usual_still_loads_favorites_into_cart_without_exposing_them(): void
+    {
+        [$shop, $product] = $this->createMenu();
+        $this->createCustomer($shop, [
+            [
+                'id' => $product->id,
+                'name' => 'Secret Wedding Order',
+                'quantity' => 2,
+                'selectedModifiers' => [],
+            ],
+        ]);
+
+        Livewire::test(GuestMenu::class, ['shop' => $shop])
+            ->set('loyaltyPhone', '99887766')
+            ->call('recognizeCustomer')
+            ->assertSet('recognizedCustomer', ['name' => 'Mohammed', 'points' => 120])
+            ->call('orderUsual')
+            ->assertSet('recognizedCustomer', ['name' => 'Mohammed', 'points' => 120])
+            ->assertSet('cart', [
+                $product->id.'-plain' => [
+                    'id' => $product->id,
+                    'name' => 'Latte',
+                    'price' => 4.5,
+                    'quantity' => 2,
+                    'selectedModifiers' => [],
+                    'modifierNames' => [],
+                ],
+            ]);
+    }
+
+    /**
+     * @return array{0: Shop, 1: Product}
+     */
+    private function createMenu(): array
+    {
+        $shop = Shop::create(['name' => 'Bite', 'slug' => 'bite']);
+        $category = Category::create(['shop_id' => $shop->id, 'name_en' => 'Coffee']);
+        $product = Product::forceCreate([
+            'shop_id' => $shop->id,
+            'category_id' => $category->id,
+            'name_en' => 'Latte',
+            'price' => 4.500,
+            'is_available' => true,
+            'is_visible' => true,
+        ]);
+
+        return [$shop, $product];
+    }
+
+    private function createCustomer(Shop $shop, array $favorites = []): LoyaltyCustomer
+    {
+        return LoyaltyCustomer::create([
+            'shop_id' => $shop->id,
+            'phone' => '99887766',
+            'name' => 'Mohammed Al-Rawahi',
+            'points' => 120,
+            'visit_count' => 9,
+            'favorites' => $favorites,
+        ]);
+    }
+}


### PR DESCRIPTION
Closes #1

## Acceptance Criteria
- [x] Browser DevTools shows the Livewire response payload contains only `name` (first token) and `points`. No `favorites`, no `customerOrderHistory`, no `visit_count`.
- [x] View has no order history block.
- [x] "Order Your Usual" still works end-to-end (manual test with a customer that has favorites).
- [x] Existing GuestMenu tests still pass.
- [x] New test added (see below).

## Test Output

```text
$ php artisan test tests/Feature/GuestMenuPrivacyTest.php tests/Feature/Livewire/GuestMenuTest.php tests/Feature/Livewire/GuestMenuSecurityTest.php

PASS  Tests\Feature\GuestMenuPrivacyTest
✓ recognize customer does not expose order history
✓ recognize customer does not expose favorites
✓ recognize customer returns only first name token
✓ order usual still loads favorites into cart without exposing them

PASS  Tests\Feature\Livewire\GuestMenuTest
✓ guest can see menu
✓ guest can add item to cart
✓ guest can submit order
✓ submit order rejects unavailable items
✓ submit order succeeds when all items available
✓ add to cart ignores unavailable product
✓ product image url includes storage prefix

PASS  Tests\Feature\Livewire\GuestMenuSecurityTest
✓ user cannot manipulate price in cart

Tests: 12 passed (30 assertions)
Duration: 0.48s
```

```text
$ ./vendor/bin/pint

PASS  272 files
```

```text
$ composer test

INFO  Configuration cache cleared successfully.

PASS  Tests\Feature\GuestMenuPrivacyTest
✓ recognize customer does not expose order history
✓ recognize customer does not expose favorites
✓ recognize customer returns only first name token
✓ order usual still loads favorites into cart without exposing them

PASS  Tests\Feature\Livewire\GuestMenuTest
✓ guest can see menu
✓ guest can add item to cart
✓ guest can submit order
✓ submit order rejects unavailable items
✓ submit order succeeds when all items available
✓ add to cart ignores unavailable product
✓ product image url includes storage prefix

Tests: 271 passed (748 assertions)
Duration: 10.54s
```

## Decisions
- Built `fix/1-loyalty-pii-leak` from `origin/main` in a separate worktree so the existing local `main` commits and dirty files do not enter this issue PR.
- Removed `customerOrderHistory` as public Livewire state instead of only hiding the view block, so order history cannot be serialized back to the browser.
- Kept `recognizedCustomer` limited to `name` and `points`; the name is now first-token only.
- Changed server loyalty reordering so `orderUsual()` loads favorites from `LoyaltyService::recognize()` using the current phone, then applies them server-side. The existing browser local-favorite feature now routes through `applySavedFavorite()` so `applyFavorite()` no longer accepts a favorites array.
- Rendered "Order Your Usual" for recognized customers without sending a `has_favorites` flag; customers with no saved server favorite get the existing empty-favorite message. This avoids leaking favorites metadata while preserving the successful path.