### PR TITLE
Fix production APP_KEY startup guard

### DIFF
--- a/bite/.planning/phases/06-containerization-cloud-services/06-01-PLAN.md
+++ b/bite/.planning/phases/06-containerization-cloud-services/06-01-PLAN.md
@@ -268,6 +268,8 @@ Output: A `docker build` that produces a container running Nginx + PHP-FPM via s
     exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
     ```
 
+    **2026-05-01 correction to the APP_KEY startup behavior:** The runtime generation block above is overruled for production. In autoscaled Cloud Run, every instance must share the same stable `APP_KEY`; generating a key per container can invalidate encrypted sessions and make encrypted stored data unrecoverable. Production startup must now fail fast when `APP_ENV=production` and `APP_KEY` is missing. Runtime generation remains acceptable only for non-production environments.
+
     **Key changes from current start.sh:**
     - Remove `touch database/database.sqlite` (no more SQLite)
     - Remove `exec php artisan serve` (replaced by supervisord)

--- a/bite/docker/start.sh
+++ b/bite/docker/start.sh
@@ -6,10 +6,17 @@ cd /var/www/html
 # Ensure writable directories exist
 mkdir -p storage/framework/cache storage/framework/sessions storage/framework/views storage/logs bootstrap/cache
 
-# Generate APP_KEY at runtime if not provided via environment (per D-10)
+# Production must use one stable key across all instances. Runtime-generated
+# production keys break encrypted sessions and any encrypted persisted data.
 if [ -z "${APP_KEY:-}" ]; then
+    if [ "${APP_ENV:-local}" = "production" ]; then
+        echo "FATAL: APP_KEY must be set in production. Set a stable Laravel APP_KEY secret before starting the container." >&2
+        echo "Generate one with: php artisan key:generate --show" >&2
+        exit 1
+    fi
+
     export APP_KEY="$(php artisan key:generate --show --no-interaction)"
-    echo "Generated APP_KEY at startup."
+    echo "WARNING: Generated APP_KEY at startup for APP_ENV=${APP_ENV:-local}. Do not use runtime-generated keys in production." >&2
 fi
 
 # Run migrations on every deploy (seeding only on first deploy — not here)

--- a/bite/docs/DEPLOYMENT.md
+++ b/bite/docs/DEPLOYMENT.md
@@ -51,6 +51,7 @@ php artisan key:generate
 ```env
 APP_NAME="Bite POS"
 APP_ENV=production
+APP_KEY=base64:GENERATED_WITH_php_artisan_key_generate_show
 APP_DEBUG=false
 APP_URL=https://bitepos.app
 
@@ -86,6 +87,37 @@ STRIPE_SUBSCRIPTION_WEBHOOK_SECRET=whsec_xxxx
 
 FORCE_HTTPS=true
 ```
+
+### Required `APP_KEY`
+`APP_KEY` is a required production secret. Generate it once, store it in the deployment secret store, and keep the same value across every app instance and revision:
+
+```bash
+php artisan key:generate --show
+```
+
+For Cloud Run, store the generated value in Secret Manager and expose it as the `APP_KEY` environment variable. Pin a specific secret version; do not reference `latest` because APP_KEY rotation is destructive.
+
+```bash
+PROJECT_ID="$(gcloud config get-value project)"
+RUNTIME_SA="$(gcloud run services describe bite-pos-demo \
+    --region us-central1 \
+    --format='value(spec.template.spec.serviceAccountName)')"
+
+printf '%s' 'base64:PASTE_GENERATED_KEY_HERE' | gcloud secrets create bite-app-key --data-file=-
+gcloud secrets add-iam-policy-binding bite-app-key \
+    --member="serviceAccount:${RUNTIME_SA}" \
+    --role="roles/secretmanager.secretAccessor"
+
+# The pinned version resource is:
+# projects/${PROJECT_ID}/secrets/bite-app-key/versions/1
+gcloud run services update bite-pos-demo \
+    --region us-central1 \
+    --update-secrets=APP_KEY=projects/${PROJECT_ID}/secrets/bite-app-key:1
+```
+
+Do not let the container generate `APP_KEY` in production. A runtime-generated key can differ between Cloud Run instances, invalidating encrypted sessions and making encrypted stored data unrecoverable.
+
+If converting an existing service from a plain `APP_KEY` environment variable, copy the exact current value into Secret Manager. Do not generate a replacement key. Deploy the secret-backed revision with 0% or low traffic first, verify it boots, then route 100% traffic to the new revision. The rollback path is the previous Cloud Run revision that still has the plain env var.
 
 ### 6. Install & Build
 ```bash


### PR DESCRIPTION
Closes #2

## Acceptance Criteria
- [x] `docker run -e APP_ENV=production bite-audit` with no `APP_KEY` exits non-zero with the APP_KEY-specific FATAL message from `docker/start.sh`.
- [x] `APP_ENV=production` with `APP_KEY=base64:...` does not exit due to APP_KEY logic; trace harness reaches the final supervisord handoff line.
- [x] `APP_ENV=local` with no `APP_KEY` still generates a runtime key and warns.
- [x] `docs/DEPLOYMENT.md` updated with an APP_KEY requirement section and `php artisan key:generate --show` example.
- [x] Cloud Run `bite-pos-demo` checked: `APP_KEY` is currently configured, but as a plain env value. Secret Manager conversion is documented here as a separate companion task and was not performed in this code PR.
- [x] Planning D-10 correction addendum added.

## Smoke Test Output

```text
$ docker build -t bite-audit .
...
writing image sha256:06980346d7a49aaf1c95624cba315c9b28355e67319e156df95ba911e7c20a31 done
naming to docker.io/library/bite-audit done
```

```text
$ docker run --rm -e APP_ENV=production bite-audit; code=$?; printf 'exit_code=%s\n' "$code"
FATAL: APP_KEY must be set in production. Set a stable Laravel APP_KEY secret before starting the container.
Generate one with: php artisan key:generate --show
exit_code=1
```

```text
$ docker run --rm --entrypoint sh -e APP_ENV=production -e APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= bite-audit -c '<trace harness: stub downstream php artisan calls; replace final supervisord exec with echo>'
+ [ -z base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= ]
+ php artisan migrate --force --no-interaction
stub php artisan migrate --force --no-interaction
+ php artisan config:cache
stub php artisan config:cache
+ php artisan route:cache
stub php artisan route:cache
+ php artisan view:cache
stub php artisan view:cache
+ mkdir -p /run
+ echo REACHED_SUPERVISORD_EXEC
REACHED_SUPERVISORD_EXEC
exit_code=0
```

```text
$ docker run --rm --entrypoint sh -e APP_ENV=local bite-audit -c '<trace harness: stub downstream php artisan calls; replace final supervisord exec with echo>'
+ [ -z  ]
+ [ local = production ]
+ php artisan key:generate --show --no-interaction
stub php artisan key:generate --show --no-interaction
+ export APP_KEY=base64:LOCAL_GENERATED_KEY
+ echo WARNING: Generated APP_KEY at startup for APP_ENV=local. Do not use runtime-generated keys in production.
WARNING: Generated APP_KEY at startup for APP_ENV=local. Do not use runtime-generated keys in production.
+ php artisan migrate --force --no-interaction
stub php artisan migrate --force --no-interaction
+ php artisan config:cache
stub php artisan config:cache
+ php artisan route:cache
stub php artisan route:cache
+ php artisan view:cache
stub php artisan view:cache
+ mkdir -p /run
REACHED_SUPERVISORD_EXEC
exit_code=0
```

## Cloud Run Check

```text
$ gcloud run services describe bite-pos-demo --region us-central1 --format=json | jq -r '<redacted APP_KEY env summary>'
- name: APP_KEY
  configured: plain env value present (redacted)

$ gcloud run services describe bite-pos-demo --region us-central1 --format='value(spec.template.spec.serviceAccountName)'
528372920943-compute@developer.gserviceaccount.com
```

## Test Output

```text
$ composer test
INFO  Configuration cache cleared successfully.
...
Tests: 271 passed (748 assertions)
Duration: 10.58s
```

```text
$ ./vendor/bin/pint
PASS  272 files
```

## Decisions
- Kept runtime APP_KEY generation for non-production environments to preserve local/staging workflows.
- Production now fails before Artisan boot when `APP_ENV=production` and `APP_KEY` is empty, so missing-key failure is clearly from `docker/start.sh` rather than downstream validation.
- Used a Docker trace harness for the positive/local smoke checks because the production image also needs real Sentry and DB runtime env to complete a full boot. The harness stubs downstream `php artisan` calls and replaces only the final supervisord `exec`, proving the APP_KEY logic reaches startup handoff.
- Secret Manager conversion is intentionally not performed in this PR. The deployed service currently has APP_KEY set as a plain env value; converting the exact current value to a pinned Secret Manager version should be done as a separate infra task/PR with revision rollback available.
- Documented the required Secret Manager companion steps: use the exact current key, grant only the runtime service account on the secret, pin version `1`, test a new revision before 100% traffic, and roll back via the previous revision if needed.
- Existing sessions may invalidate on future deploy only if APP_KEY is changed. This PR does not change the deployed APP_KEY value.