### PR TITLE
Fix suspended shop status enforcement

### DIFF
--- a/bite/app/Http/Middleware/EnsureShopActive.php
+++ b/bite/app/Http/Middleware/EnsureShopActive.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureShopActive
+{
+    /**
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if (! $user || $user->is_super_admin) {
+            return $next($request);
+        }
+
+        if ($user->shop?->status === 'suspended') {
+            return response()->view('suspended', status: 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/bite/bootstrap/app.php
+++ b/bite/bootstrap/app.php
@@ -39,6 +39,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'super_admin' => \App\Http\Middleware\EnsureUserIsSuperAdmin::class,
             'role' => \App\Http\Middleware\EnsureUserHasRole::class,
             'subscribed' => \App\Http\Middleware\CheckSubscription::class,
+            'shop.active' => \App\Http\Middleware\EnsureShopActive::class,
         ]);
 
         $middleware->redirectTo(

--- a/bite/resources/views/suspended.blade.php
+++ b/bite/resources/views/suspended.blade.php
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Account Suspended - {{ config('app.name', 'Bite POS') }}</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="min-h-screen bg-body text-ink antialiased">
+    <main class="flex min-h-screen items-center justify-center px-6 py-12">
+        <section class="w-full max-w-md rounded-lg border border-line bg-panel px-6 py-8 text-center shadow-sm">
+            <p class="font-mono text-[10px] font-semibold uppercase tracking-[0.18em] text-ink-soft">
+                {{ config('app.name', 'Bite POS') }}
+            </p>
+            <h1 class="mt-4 text-2xl font-bold text-ink">This account has been suspended.</h1>
+            <p class="mt-3 text-sm leading-6 text-ink-soft">Contact support.</p>
+        </section>
+    </main>
+</body>
+</html>

--- a/bite/routes/web.php
+++ b/bite/routes/web.php
@@ -57,17 +57,17 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::get('onboarding', OnboardingWizard::class)->name('onboarding');
 });
 
-Route::middleware(['auth', 'subscribed', 'role:server,manager,admin'])->group(function () {
+Route::middleware(['auth', 'subscribed', 'shop.active', 'role:server,manager,admin'])->group(function () {
     Route::get('/pos', PosDashboard::class)->name('pos.dashboard');
     Route::get('/orders/{order}/invoice', [InvoiceController::class, 'show'])->name('admin.orders.invoice');
     Route::get('/receipt/{order}', [ReceiptController::class, 'show'])->name('receipt.print');
 });
 
-Route::middleware(['auth', 'subscribed', 'role:kitchen,manager,admin'])->group(function () {
+Route::middleware(['auth', 'subscribed', 'shop.active', 'role:kitchen,manager,admin'])->group(function () {
     Route::get('/kds', KitchenDisplay::class)->name('kds.view');
 });
 
-Route::middleware(['auth', 'subscribed', 'role:manager,admin'])->group(function () {
+Route::middleware(['auth', 'subscribed', 'shop.active', 'role:manager,admin'])->group(function () {
     Route::get('/products', ProductManager::class)->name('admin.products');
     Route::get('/menu-builder', MenuBuilder::class)->name('admin.menu-builder');
     Route::get('/modifiers', ModifierManager::class)->name('admin.modifiers');

--- a/bite/tests/Feature/SuspendedShopTest.php
+++ b/bite/tests/Feature/SuspendedShopTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Shop;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SuspendedShopTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_suspended_shop_user_blocked_from_pos(): void
+    {
+        $user = $this->makeUser('admin', 'suspended');
+
+        $this->actingAs($user)
+            ->get('/pos')
+            ->assertForbidden()
+            ->assertSee('This account has been suspended.')
+            ->assertSee('Contact support.');
+    }
+
+    public function test_suspended_shop_user_blocked_from_kds(): void
+    {
+        $user = $this->makeUser('admin', 'suspended');
+
+        $this->actingAs($user)
+            ->get('/kds')
+            ->assertForbidden()
+            ->assertSee('This account has been suspended.');
+    }
+
+    public function test_suspended_shop_user_blocked_from_products_and_reports(): void
+    {
+        $user = $this->makeUser('admin', 'suspended');
+
+        foreach (['/products', '/reports'] as $path) {
+            $this->actingAs($user)
+                ->get($path)
+                ->assertForbidden()
+                ->assertSee('This account has been suspended.');
+        }
+    }
+
+    public function test_suspended_shop_user_can_still_access_billing(): void
+    {
+        $user = $this->makeUser('admin', 'suspended');
+
+        $this->actingAs($user)
+            ->get('/billing')
+            ->assertOk()
+            ->assertDontSee('This account has been suspended.');
+    }
+
+    public function test_active_shop_user_can_access_pos(): void
+    {
+        $user = $this->makeUser('admin', 'active');
+
+        $this->actingAs($user)
+            ->get('/pos')
+            ->assertOk()
+            ->assertDontSee('This account has been suspended.');
+    }
+
+    public function test_super_admin_unaffected_by_suspension(): void
+    {
+        $user = $this->makeUser('admin', 'suspended', isSuperAdmin: true);
+
+        $this->actingAs($user)
+            ->get('/pos')
+            ->assertOk()
+            ->assertDontSee('This account has been suspended.');
+    }
+
+    private function makeUser(string $role, string $shopStatus, bool $isSuperAdmin = false): User
+    {
+        $shop = Shop::factory()->create();
+        $shop->status = $shopStatus;
+        $shop->save();
+
+        return User::factory()->create([
+            'shop_id' => $shop->id,
+            'role' => $role,
+            'is_super_admin' => $isSuperAdmin,
+        ]);
+    }
+}


### PR DESCRIPTION
Closes #3

## Acceptance Criteria
- [x] Suspended shop user -> `/pos`, `/kds`, `/products`, `/reports` all return the suspension page.
- [x] Suspended shop user -> `/billing` still loads.
- [x] Active shop user -> no behavioral change anywhere.
- [x] Super admin -> unaffected even if their assigned shop is suspended.
- [x] Test passes for each of the four scenarios.

## Test Output
```text
$ ./vendor/bin/pint

  ............................................................................
  ............................................................................
  ............................................................................
  ..............................................

  ──────────────────────────────────────────────────────────────────── Laravel
    PASS   ......................................................... 274 files
```

```text
$ composer test

   PASS  Tests\Feature\SuspendedShopTest
  ✓ suspended shop user blocked from pos                                 0.01s
  ✓ suspended shop user blocked from kds                                 0.01s
  ✓ suspended shop user blocked from products and reports                0.01s
  ✓ suspended shop user can still access billing                         0.01s
  ✓ active shop user can access pos                                      0.01s
  ✓ super admin unaffected by suspension                                 0.01s

  Tests:    277 passed (763 assertions)
  Duration: 10.77s
```

## Decisions
- Registered the new middleware as `shop.active` and applied it in the requested order: `auth` -> `subscribed` -> `shop.active` -> `role`.
- Kept `/billing` outside the suspension middleware so suspended shops can still reach billing/reactivation paths.
- Left super admins exempt from suspension blocking, even when their assigned shop is suspended.
- Kept the suspension view minimal. I did not add a logout link because this app does not define a named `logout` route.
- Added combined `/products` and `/reports` coverage in addition to the specifically named route tests so the full blocked-route acceptance criterion is exercised.
