### PR TITLE
Fix KDS modifier snapshot rendering

### DIFF
--- a/bite/app/Livewire/KitchenDisplay.php
+++ b/bite/app/Livewire/KitchenDisplay.php
@@ -70,7 +70,7 @@ class KitchenDisplay extends Component
     {
         $orders = Order::where('shop_id', Auth::user()->shop_id)
             ->whereIn('status', ['paid', 'preparing'])
-            ->with('items') // Eager load items for KDS
+            ->with('items.modifiers') // Eager load items and modifier snapshots for KDS
             ->oldest() // First in, First out
             ->get();
 

--- a/bite/app/Models/OrderItemModifier.php
+++ b/bite/app/Models/OrderItemModifier.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
+use App\Traits\HasTranslations;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class OrderItemModifier extends Model
 {
-    use HasFactory;
+    use HasFactory, HasTranslations;
 
     protected $fillable = [
         'order_item_id',

--- a/bite/resources/views/livewire/kitchen-display.blade.php
+++ b/bite/resources/views/livewire/kitchen-display.blade.php
@@ -81,7 +81,17 @@
                         @foreach($order->items as $item)
                             <li class="flex items-start gap-3 rounded-lg border border-panel/15 bg-panel/10 px-3 py-2.5">
                                 <span class="inline-flex min-w-10 items-center justify-center rounded-md bg-crema px-2 py-1 font-mono text-sm font-bold uppercase text-panel">{{ $item->quantity }}x</span>
-                                <span class="text-lg font-bold uppercase tracking-tight text-panel">{{ $item->translated('product_name_snapshot') }}</span>
+                                <div class="min-w-0">
+                                    <span class="text-lg font-bold uppercase tracking-tight text-panel">{{ $item->translated('product_name_snapshot') }}</span>
+
+                                    @if($item->modifiers->isNotEmpty())
+                                        <ul class="mt-1 space-y-0.5 pl-1 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] text-panel/65">
+                                            @foreach($item->modifiers as $modifier)
+                                                <li>+ {{ $modifier->translated('modifier_option_name_snapshot') }}</li>
+                                            @endforeach
+                                        </ul>
+                                    @endif
+                                </div>
                             </li>
                         @endforeach
                     </ul>

--- a/bite/tests/Feature/KitchenDisplayModifiersTest.php
+++ b/bite/tests/Feature/KitchenDisplayModifiersTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\KitchenDisplay;
+use App\Models\Category;
+use App\Models\ModifierGroup;
+use App\Models\ModifierOption;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\OrderItemModifier;
+use App\Models\Product;
+use App\Models\Shop;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class KitchenDisplayModifiersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_modifiers_appear_in_render(): void
+    {
+        [$shop, $user] = $this->makeKitchenUser();
+        $item = $this->createPaidOrderItem($shop, [
+            'product_name_snapshot_en' => 'Falafel Wrap',
+            'quantity' => 2,
+        ]);
+
+        $this->createModifier($item, 'No Onions');
+        $this->createModifier($item, 'Extra Cheese');
+
+        Livewire::actingAs($user)
+            ->test(KitchenDisplay::class)
+            ->assertSee('Falafel Wrap')
+            ->assertSee('2x')
+            ->assertSee('No Onions')
+            ->assertSee('Extra Cheese');
+    }
+
+    public function test_no_modifiers_does_not_break_render(): void
+    {
+        [$shop, $user] = $this->makeKitchenUser();
+
+        $this->createPaidOrderItem($shop, [
+            'product_name_snapshot_en' => 'Plain Burger',
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(KitchenDisplay::class)
+            ->assertSee('Plain Burger')
+            ->assertDontSee('No Onions')
+            ->assertDontSeeHtml('space-y-0.5 pl-1');
+    }
+
+    public function test_uses_snapshot_not_live_data(): void
+    {
+        [$shop, $user] = $this->makeKitchenUser();
+        [$product, $option] = $this->createProductWithModifierOption($shop, 'Oat Milk');
+
+        $item = $this->createPaidOrderItem($shop, [
+            'product_id' => $product->id,
+            'product_name_snapshot_en' => 'Latte',
+        ]);
+        $this->createModifier($item, 'Oat Milk');
+
+        $option->update(['name_en' => 'Soy Milk']);
+
+        Livewire::actingAs($user)
+            ->test(KitchenDisplay::class)
+            ->assertSee('Latte')
+            ->assertSee('Oat Milk')
+            ->assertDontSee('Soy Milk');
+    }
+
+    public function test_no_n_plus_one_with_many_orders(): void
+    {
+        [$shop, $user] = $this->makeKitchenUser();
+
+        for ($i = 0; $i < 25; $i++) {
+            $item = $this->createPaidOrderItem($shop, [
+                'product_name_snapshot_en' => 'Ticket Item '.$i,
+            ]);
+
+            $this->createModifier($item, 'Modifier '.$i);
+        }
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        Livewire::actingAs($user)
+            ->test(KitchenDisplay::class)
+            ->assertSee('Ticket Item 0')
+            ->assertSee('Modifier 24');
+
+        $queries = collect(DB::getQueryLog())->pluck('query');
+        DB::disableQueryLog();
+
+        $orderItemQueries = $queries
+            ->filter(fn (string $query): bool => str_contains($query, 'order_items'))
+            ->values();
+        $modifierQueries = $queries
+            ->filter(fn (string $query): bool => str_contains($query, 'order_item_modifiers'))
+            ->values();
+
+        $this->assertCount(1, $orderItemQueries, $orderItemQueries->implode(PHP_EOL));
+        $this->assertCount(1, $modifierQueries, $modifierQueries->implode(PHP_EOL));
+    }
+
+    private function makeKitchenUser(): array
+    {
+        $shop = Shop::factory()->create();
+        $user = User::factory()->create([
+            'shop_id' => $shop->id,
+            'role' => 'kitchen',
+        ]);
+
+        return [$shop, $user];
+    }
+
+    private function createPaidOrderItem(Shop $shop, array $attributes = []): OrderItem
+    {
+        $order = Order::forceCreate([
+            'shop_id' => $shop->id,
+            'status' => 'paid',
+            'total_amount' => 15.00,
+            'paid_at' => now(),
+        ]);
+
+        return OrderItem::create(array_merge([
+            'order_id' => $order->id,
+            'product_id' => null,
+            'product_name_snapshot_en' => 'Kitchen Item',
+            'product_name_snapshot_ar' => null,
+            'price_snapshot' => 5.00,
+            'quantity' => 1,
+        ], $attributes));
+    }
+
+    private function createModifier(OrderItem $item, string $name): OrderItemModifier
+    {
+        return OrderItemModifier::create([
+            'order_item_id' => $item->id,
+            'modifier_option_name_snapshot_en' => $name,
+            'modifier_option_name_snapshot_ar' => null,
+            'price_adjustment_snapshot' => 0.50,
+        ]);
+    }
+
+    private function createProductWithModifierOption(Shop $shop, string $optionName): array
+    {
+        $category = Category::create([
+            'shop_id' => $shop->id,
+            'name_en' => 'Drinks',
+            'name_ar' => null,
+        ]);
+
+        $product = Product::forceCreate([
+            'shop_id' => $shop->id,
+            'category_id' => $category->id,
+            'name_en' => 'Latte',
+            'name_ar' => null,
+            'description_en' => null,
+            'description_ar' => null,
+            'price' => 3.00,
+            'is_available' => true,
+        ]);
+
+        $group = ModifierGroup::create([
+            'shop_id' => $shop->id,
+            'name_en' => 'Milk',
+            'name_ar' => null,
+            'min_selection' => 0,
+            'max_selection' => 1,
+        ]);
+
+        $option = ModifierOption::create([
+            'modifier_group_id' => $group->id,
+            'name_en' => $optionName,
+            'name_ar' => null,
+            'price_adjustment' => 0.50,
+        ]);
+
+        $product->modifierGroups()->attach($group->id);
+
+        return [$product, $option];
+    }
+}


### PR DESCRIPTION
Closes #4

## Acceptance Criteria
- [x] KDS shows item with its modifiers indented or comma-separated below the line
- [x] Modifier text reads from snapshot fields, not live relationship (verified by changing modifier name in DB after order placed -> KDS still shows original)
- [x] Order with no modifiers renders unchanged
- [x] Performance: no N+1 query when KDS has 20+ orders (verify with query log or `DB::enableQueryLog()`)
- [x] Test passes

## Test Output
```text
$ php artisan test tests/Feature/KitchenDisplayModifiersTest.php tests/Feature/Livewire/KitchenDisplayTest.php tests/Feature/Livewire/KitchenDisplayTenantIsolationTest.php

   PASS  Tests\Feature\KitchenDisplayModifiersTest
  ✓ modifiers appear in render                                           0.24s
  ✓ no modifiers does not break render                                   0.01s
  ✓ uses snapshot not live data                                          0.01s
  ✓ no n plus one with many orders                                       0.02s

   PASS  Tests\Feature\Livewire\KitchenDisplayTest
  ✓ kitchen sees paid orders only                                        0.01s
  ✓ kitchen can update order status                                      0.01s

   PASS  Tests\Feature\Livewire\KitchenDisplayTenantIsolationTest
  ✓ cannot transition another shops order to preparing                   0.01s
  ✓ cannot transition another shops order to ready                       0.01s
  ✓ kds does not render another shops orders                             0.01s

  Tests:    9 passed (21 assertions)
  Duration: 0.38s
```

```text
$ ./vendor/bin/pint

  ............................................................................
  ............................................................................
  ............................................................................
  ...............................................

  ──────────────────────────────────────────────────────────────────── Laravel
    PASS   ......................................................... 275 files
```

```text
$ composer test

   PASS  Tests\Feature\KitchenDisplayModifiersTest
  ✓ modifiers appear in render                                           0.01s
  ✓ no modifiers does not break render                                   0.01s
  ✓ uses snapshot not live data                                          0.01s
  ✓ no n plus one with many orders                                       0.02s

  Tests:    281 passed (777 assertions)
  Duration: 10.75s
```

## Decisions
- Used locale-based snapshot rendering by adding the existing `HasTranslations` helper to `OrderItemModifier`; this follows the current `App::getLocale()` pattern already used for KDS product-name snapshots.
- Rendered modifiers as smaller, indented text under the product name so they are visually subordinate to quantity and item name.
- Kept the no-modifier branch empty so items without modifiers do not render an empty list or extra modifier spacing.
- Verified the N+1 criterion with `DB::enableQueryLog()` in `test_no_n_plus_one_with_many_orders`; 25 orders produce one `order_items` query and one `order_item_modifiers` query.
- Left `oldest()` ordering and `lastOrderCount`/`kds-new-order` dispatch logic unchanged.
