### PR TITLE
Fix product image uploads on default disk

### DIFF
--- a/bite/app/Console/Commands/OptimizeImages.php
+++ b/bite/app/Console/Commands/OptimizeImages.php
@@ -19,6 +19,7 @@ class OptimizeImages extends Command
         $processed = 0;
         $skipped = 0;
         $failed = 0;
+        $disk = config('filesystems.default');
 
         $this->info("Found {$products->count()} products with images.");
 
@@ -32,7 +33,7 @@ class OptimizeImages extends Command
             }
 
             // Skip if source file doesn't exist on disk
-            if (! Storage::disk('public')->exists($product->image_url)) {
+            if (! Storage::disk($disk)->exists($product->image_url)) {
                 $failed++;
                 $this->warn("  MISS: {$product->name_en} — file not found: {$product->image_url}");
 

--- a/bite/app/Livewire/ProductManager.php
+++ b/bite/app/Livewire/ProductManager.php
@@ -120,7 +120,7 @@ class ProductManager extends Component
             $oldImageUrl = $product->image_url;
             $imageUrl = $product->image_url;
             if ($this->image) {
-                $rawPath = $this->image->store('products', 'public');
+                $rawPath = $this->image->store('products', config('filesystems.default'));
                 try {
                     $imageService = app(ImageService::class);
                     $imageUrl = $imageService->processUpload($rawPath);
@@ -154,7 +154,7 @@ class ProductManager extends Component
 
         $imageUrl = null;
         if ($this->image) {
-            $rawPath = $this->image->store('products', 'public');
+            $rawPath = $this->image->store('products', config('filesystems.default'));
             try {
                 $imageService = app(ImageService::class);
                 $imageUrl = $imageService->processUpload($rawPath);

--- a/bite/app/Services/ImageService.php
+++ b/bite/app/Services/ImageService.php
@@ -45,8 +45,10 @@ class ImageService
      *
      * @throws \Throwable on encode/save failure (original is preserved)
      */
-    public function processUpload(string $storedPath, string $disk = 'public'): string
+    public function processUpload(string $storedPath, ?string $disk = null): string
     {
+        $disk ??= config('filesystems.default');
+
         $contents = Storage::disk($disk)->get($storedPath);
         $ext = $this->supportsWebp() ? 'webp' : 'jpg';
 
@@ -86,8 +88,10 @@ class ImageService
      * Derives baseName by removing the "-full" suffix and extension.
      * Deletes thumb, card, and full variants — no exception on missing files.
      */
-    public function deleteVariants(string $imageUrl, string $disk = 'public'): void
+    public function deleteVariants(string $imageUrl, ?string $disk = null): void
     {
+        $disk ??= config('filesystems.default');
+
         // Match the base name before "-full.ext"
         if (! preg_match('/^(.+)-full(\.[^.]+)$/', $imageUrl, $matches)) {
             return;

--- a/bite/tests/Feature/ImageServiceTest.php
+++ b/bite/tests/Feature/ImageServiceTest.php
@@ -9,6 +9,13 @@ use Tests\TestCase;
 
 class ImageServiceTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['filesystems.default' => 'public']);
+    }
+
     public function test_process_upload_creates_three_webp_variants(): void
     {
         Storage::fake('public');
@@ -143,8 +150,10 @@ class ImageServiceTest extends TestCase
                 return true;
             }
 
-            public function processUpload(string $storedPath, string $disk = 'public'): string
+            public function processUpload(string $storedPath, ?string $disk = null): string
             {
+                $disk ??= config('filesystems.default');
+
                 $contents = \Illuminate\Support\Facades\Storage::disk($disk)->get($storedPath);
                 $ext = 'webp';
                 $baseName = preg_replace('/\.[^.]+$/', '', $storedPath);

--- a/bite/tests/Feature/OptimizeImagesCommandTest.php
+++ b/bite/tests/Feature/OptimizeImagesCommandTest.php
@@ -15,6 +15,13 @@ class OptimizeImagesCommandTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['filesystems.default' => 'public']);
+    }
+
     /**
      * Test 1: Command processes a product with an unoptimized image.
      * After running, the product's image_url is updated to the -full.webp path.

--- a/bite/tests/Feature/ProductImageUploadTest.php
+++ b/bite/tests/Feature/ProductImageUploadTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\ProductManager;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\Shop;
+use App\Models\User;
+use App\Services\ImageService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ProductImageUploadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_upload_writes_variants_to_default_disk(): void
+    {
+        $disk = $this->fakeDefaultDisk('gcs');
+        [$user, $category] = $this->makeCatalogUser();
+
+        Livewire::actingAs($user)
+            ->test(ProductManager::class)
+            ->set('name_en', 'Flat White')
+            ->set('price', 1.500)
+            ->set('category_id', $category->id)
+            ->set('image', UploadedFile::fake()->image('flat-white.jpg', 900, 700))
+            ->call('save');
+
+        $product = Product::where('name_en', 'Flat White')->firstOrFail();
+        $baseName = preg_replace('/-full\.[^.]+$/', '', $product->image_url);
+        $extension = pathinfo($product->image_url, PATHINFO_EXTENSION);
+
+        Storage::disk($disk)->assertExists("{$baseName}-thumb.{$extension}");
+        Storage::disk($disk)->assertExists("{$baseName}-card.{$extension}");
+        Storage::disk($disk)->assertExists("{$baseName}-full.{$extension}");
+    }
+
+    public function test_delete_removes_variants_from_default_disk(): void
+    {
+        $disk = $this->fakeDefaultDisk('gcs');
+
+        Storage::disk($disk)->put('products/coffee-thumb.webp', 'fake');
+        Storage::disk($disk)->put('products/coffee-card.webp', 'fake');
+        Storage::disk($disk)->put('products/coffee-full.webp', 'fake');
+
+        app(ImageService::class)->deleteVariants('products/coffee-full.webp');
+
+        Storage::disk($disk)->assertMissing('products/coffee-thumb.webp');
+        Storage::disk($disk)->assertMissing('products/coffee-card.webp');
+        Storage::disk($disk)->assertMissing('products/coffee-full.webp');
+    }
+
+    public function test_url_helper_resolves_uploaded_image(): void
+    {
+        $this->fakeDefaultDisk('gcs');
+
+        $product = new Product;
+        $product->image_url = 'products/latte-full.webp';
+
+        $url = productImage($product, 'card');
+
+        $this->assertNotNull($url);
+        $this->assertStringContainsString('products/latte-card.webp', $url);
+    }
+
+    private function fakeDefaultDisk(string $disk): string
+    {
+        config(['filesystems.default' => $disk]);
+        Storage::fake(config('filesystems.default'));
+
+        return config('filesystems.default');
+    }
+
+    private function makeCatalogUser(): array
+    {
+        $shop = Shop::factory()->create();
+        $user = User::factory()->create([
+            'shop_id' => $shop->id,
+            'role' => 'admin',
+        ]);
+        $category = Category::factory()->create(['shop_id' => $shop->id]);
+
+        return [$user, $category];
+    }
+}

--- a/bite/tests/Feature/ProductManagerImageTest.php
+++ b/bite/tests/Feature/ProductManagerImageTest.php
@@ -26,6 +26,9 @@ class ProductManagerImageTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        config(['filesystems.default' => 'public']);
+
         $this->shop = Shop::factory()->create();
         $this->user = User::factory()->create(['shop_id' => $this->shop->id]);
         $this->category = Category::factory()->create(['shop_id' => $this->shop->id]);


### PR DESCRIPTION
Closes #5

## Acceptance Criteria
- [x] Local dev: upload product image -> renders correctly (unchanged behavior)
- [x] Test with `FILESYSTEM_DISK=gcs` (use a sandbox bucket if available) -> file lands in bucket, URL resolves
- [x] No `Storage::disk('public')` or `'public'` literal in upload paths after fix (grep proves it)
- [x] `ImageService::deleteVariants` correctly removes from the same disk
- [x] Test uses `Storage::fake(config('filesystems.default'))` and asserts variants exist

## Test Output
```text
$ php artisan test tests/Feature/ProductImageUploadTest.php tests/Feature/ImageServiceTest.php tests/Feature/ProductManagerImageTest.php tests/Feature/OptimizeImagesCommandTest.php

   PASS  Tests\Feature\ProductImageUploadTest
  ✓ upload writes variants to default disk                               0.35s
  ✓ delete removes variants from default disk                            0.01s
  ✓ url helper resolves uploaded image                                   0.01s

   PASS  Tests\Feature\ImageServiceTest
  ✓ process upload creates three webp variants                           0.04s
  ✓ process upload deletes original after variants                       0.04s
  ✓ process upload creates jpeg variants when webp unsupported           0.04s
  ✓ delete variants removes all three files                              0.01s
  ✓ delete variants does not throw when files missing                    0.01s
  ✓ product image helper returns card url                                0.01s
  ✓ product image helper returns null when no image                      0.01s
  ✓ product image helper returns null for null product                   0.01s
  ✓ process upload resizes to correct dimensions                         0.04s
  ✓ original survives when variant save fails                            0.01s

   PASS  Tests\Feature\ProductManagerImageTest
  ✓ saving product with jpeg image creates webp variants                 0.06s
  ✓ saving product with png image creates webp variants                  0.07s
  ✓ editing product with new image deletes old variants                  0.06s
  ✓ validation rejects files over 5mb                                    0.02s
  ✓ validation rejects gif files                                         0.02s

   PASS  Tests\Feature\OptimizeImagesCommandTest
  ✓ command processes product with image                                 0.02s
  ✓ command skips null image products                                    0.01s
  ✓ command skips already processed images                               0.01s
  ✓ command reports counts                                               0.01s
  ✓ command handles missing source files gracefully                      0.01s

  Tests:    23 passed (53 assertions)
  Duration: 0.93s
```

```text
$ rg -n "Storage::disk\('public'\)|store\('products', 'public'\)" app || true
# no output

$ rg -n "disk\('public'\)|store\('products', 'public'\)|disk\(\"public\"\)|store\(\"products\", \"public\"\)" app || true
# no output
```

```text
$ ./vendor/bin/pint

  ............................................................................
  ............................................................................
  ............................................................................
  ................................................

  ──────────────────────────────────────────────────────────────────── Laravel
    PASS   ......................................................... 276 files
```

```text
$ composer test

   PASS  Tests\Feature\ProductImageUploadTest
  ✓ upload writes variants to default disk                               0.06s
  ✓ delete removes variants from default disk                            0.01s
  ✓ url helper resolves uploaded image                                   0.01s

  Tests:    284 passed (785 assertions)
  Duration: 10.98s
```

## Decisions
- `ImageService::processUpload()` and `deleteVariants()` now accept `?string $disk = null` and resolve null to `config('filesystems.default')` inside the method.
- `ProductManager` passes `config('filesystems.default')` explicitly to Livewire upload storage so the raw upload and generated variants stay on the same disk.
- Updated `images:optimize` to check the configured default disk for existing product images, removing the remaining app-side hardcoded public disk in the product-image path.
- The `FILESYSTEM_DISK=gcs` behavior is covered with Laravel's fake `gcs` disk via `Storage::fake(config('filesystems.default'))`; no live sandbox GCS credentials were available in this workspace.
- Before deploying with real GCS, confirm the Cloud Run runtime service account can write/delete objects in the configured `GCS_BUCKET`.
- Existing local-image tests now pin their intended default disk to `public`, preserving local dev behavior while allowing non-public defaults to be tested separately.
