### PR TITLE
Fix Pro plan route gating

### DIFF
--- a/bite/app/Http/Middleware/EnsurePlanFeature.php
+++ b/bite/app/Http/Middleware/EnsurePlanFeature.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Services\BillingService;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsurePlanFeature
+{
+    public function __construct(protected BillingService $billing)
+    {
+        //
+    }
+
+    /**
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next, string $feature): Response
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            return $next($request);
+        }
+
+        if ($user->is_super_admin) {
+            return $next($request);
+        }
+
+        if (! $user->shop) {
+            return $next($request);
+        }
+
+        if ($this->billing->canAccess($user->shop, $feature)) {
+            return $next($request);
+        }
+
+        session()->flash('billing_notice', 'This feature requires Pro plan.');
+
+        return redirect()->route('billing');
+    }
+}

--- a/bite/app/Services/BillingService.php
+++ b/bite/app/Services/BillingService.php
@@ -175,10 +175,16 @@ class BillingService
                 return $shop->products()->count() < $limit;
 
             case 'reports':
-                return in_array('Reports & Analytics', $planConfig['features']);
+                return in_array('Reports & Analytics', $planConfig['features'], true);
+
+            case 'menu_engineering':
+                return in_array('Menu Engineering', $planConfig['features'], true);
+
+            case 'pricing_rules':
+                return in_array('Pricing Rules', $planConfig['features'], true);
 
             default:
-                return true;
+                return false;
         }
     }
 

--- a/bite/bootstrap/app.php
+++ b/bite/bootstrap/app.php
@@ -40,6 +40,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'role' => \App\Http\Middleware\EnsureUserHasRole::class,
             'subscribed' => \App\Http\Middleware\CheckSubscription::class,
             'shop.active' => \App\Http\Middleware\EnsureShopActive::class,
+            'plan' => \App\Http\Middleware\EnsurePlanFeature::class,
         ]);
 
         $middleware->redirectTo(

--- a/bite/config/billing.php
+++ b/bite/config/billing.php
@@ -36,6 +36,8 @@ return [
                 'Unlimited Staff',
                 'Unlimited Products',
                 'Reports & Analytics',
+                'Menu Engineering',
+                'Pricing Rules',
                 'Priority Support',
             ],
         ],

--- a/bite/routes/web.php
+++ b/bite/routes/web.php
@@ -71,14 +71,14 @@ Route::middleware(['auth', 'subscribed', 'shop.active', 'role:manager,admin'])->
     Route::get('/products', ProductManager::class)->name('admin.products');
     Route::get('/menu-builder', MenuBuilder::class)->name('admin.menu-builder');
     Route::get('/modifiers', ModifierManager::class)->name('admin.modifiers');
-    Route::get('/reports', ReportsDashboard::class)->name('admin.reports');
-    Route::get('/reports/export', [ReportsExportController::class, 'orders'])->name('admin.reports.export');
+    Route::get('/reports', ReportsDashboard::class)->middleware('plan:reports')->name('admin.reports');
+    Route::get('/reports/export', [ReportsExportController::class, 'orders'])->middleware('plan:reports')->name('admin.reports.export');
     Route::get('/audit-logs', AuditLogs::class)->name('admin.audit-logs');
     Route::get('/settings', ShopSettings::class)->name('admin.settings');
     Route::get('/shift-report', ShiftReport::class)->name('admin.shift-report');
     Route::get('/cash-reconciliation', CashReconciliation::class)->name('admin.cash-reconciliation');
-    Route::get('/menu-engineering', MenuEngineering::class)->name('admin.menu-engineering');
-    Route::get('/pricing-rules', PricingRules::class)->name('admin.pricing-rules');
+    Route::get('/menu-engineering', MenuEngineering::class)->middleware('plan:menu_engineering')->name('admin.menu-engineering');
+    Route::get('/pricing-rules', PricingRules::class)->middleware('plan:pricing_rules')->name('admin.pricing-rules');
 });
 
 Route::middleware(['auth', 'role:admin'])->group(function () {

--- a/bite/tests/Feature/PlanGatingTest.php
+++ b/bite/tests/Feature/PlanGatingTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Shop;
+use App\Models\User;
+use App\Services\BillingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PlanGatingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const UPGRADE_MESSAGE = 'This feature requires Pro plan.';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['billing.plans.pro.stripe_price_id' => 'price_pro_test']);
+    }
+
+    public function test_free_plan_blocked_from_reports(): void
+    {
+        $user = $this->makeUserForPlan('free');
+
+        $this->assertFreeUserBlocked($user, '/reports');
+    }
+
+    public function test_pro_plan_allowed_to_reports(): void
+    {
+        $user = $this->makeUserForPlan('pro');
+
+        $this->actingAs($user)
+            ->get('/reports')
+            ->assertOk();
+    }
+
+    public function test_trial_user_treated_as_pro(): void
+    {
+        $user = $this->makeUserForPlan('trial');
+
+        $this->actingAs($user)
+            ->get('/reports')
+            ->assertOk();
+    }
+
+    public function test_super_admin_bypasses_plan_gating(): void
+    {
+        $shop = $this->makeShop('free');
+        $superAdmin = User::factory()->superAdmin()->create([
+            'shop_id' => $shop->id,
+            'role' => 'admin',
+        ]);
+
+        $this->actingAs($superAdmin)
+            ->get('/reports')
+            ->assertOk();
+    }
+
+    public function test_billing_route_remains_accessible_to_free_users(): void
+    {
+        $user = $this->makeUserForPlan('free');
+
+        $this->actingAs($user)
+            ->get('/billing')
+            ->assertOk()
+            ->assertSessionMissing('billing_notice');
+    }
+
+    public function test_free_plan_blocked_from_reports_export(): void
+    {
+        $user = $this->makeUserForPlan('free');
+
+        $this->assertFreeUserBlocked($user, '/reports/export');
+    }
+
+    public function test_pro_plan_allowed_to_reports_export(): void
+    {
+        $user = $this->makeUserForPlan('pro');
+
+        $this->actingAs($user)
+            ->get('/reports/export')
+            ->assertOk();
+    }
+
+    public function test_free_plan_blocked_from_menu_engineering(): void
+    {
+        $user = $this->makeUserForPlan('free');
+
+        $this->assertFreeUserBlocked($user, '/menu-engineering');
+    }
+
+    public function test_pro_plan_allowed_to_menu_engineering(): void
+    {
+        $user = $this->makeUserForPlan('pro');
+
+        $this->actingAs($user)
+            ->get('/menu-engineering')
+            ->assertOk();
+    }
+
+    public function test_trial_user_allowed_to_menu_engineering(): void
+    {
+        $user = $this->makeUserForPlan('trial');
+
+        $this->actingAs($user)
+            ->get('/menu-engineering')
+            ->assertOk();
+    }
+
+    public function test_free_plan_blocked_from_pricing_rules(): void
+    {
+        $user = $this->makeUserForPlan('free');
+
+        $this->assertFreeUserBlocked($user, '/pricing-rules');
+    }
+
+    public function test_pro_plan_allowed_to_pricing_rules(): void
+    {
+        $user = $this->makeUserForPlan('pro');
+
+        $this->actingAs($user)
+            ->get('/pricing-rules')
+            ->assertOk();
+    }
+
+    public function test_trial_user_allowed_to_pricing_rules(): void
+    {
+        $user = $this->makeUserForPlan('trial');
+
+        $this->actingAs($user)
+            ->get('/pricing-rules')
+            ->assertOk();
+    }
+
+    public function test_billing_service_handles_every_gated_feature(): void
+    {
+        $billing = app(BillingService::class);
+        $freeShop = $this->makeShop('free');
+        $proShop = $this->makeShop('pro');
+
+        foreach (['reports', 'menu_engineering', 'pricing_rules'] as $feature) {
+            $this->assertFalse($billing->canAccess($freeShop, $feature), "{$feature} should be blocked on Free.");
+            $this->assertTrue($billing->canAccess($proShop, $feature), "{$feature} should be allowed on Pro.");
+        }
+
+        $this->assertFalse($billing->canAccess($proShop, 'unknown_feature'));
+    }
+
+    private function assertFreeUserBlocked(User $user, string $path): void
+    {
+        $this->actingAs($user)
+            ->get($path)
+            ->assertRedirect(route('billing'))
+            ->assertSessionHas('billing_notice', self::UPGRADE_MESSAGE);
+    }
+
+    private function makeUserForPlan(string $plan): User
+    {
+        $shop = $this->makeShop($plan);
+
+        return User::factory()->create([
+            'shop_id' => $shop->id,
+            'role' => 'admin',
+        ]);
+    }
+
+    private function makeShop(string $plan): Shop
+    {
+        $shop = Shop::factory()->create();
+        $shop->trial_ends_at = null;
+        $shop->save();
+
+        if ($plan === 'trial') {
+            $shop->trial_ends_at = now()->addDays(14);
+            $shop->save();
+        }
+
+        if ($plan === 'pro') {
+            $shop->subscriptions()->create([
+                'type' => 'default',
+                'stripe_id' => 'sub_test_'.$shop->id,
+                'stripe_status' => 'active',
+                'stripe_price' => config('billing.plans.pro.stripe_price_id'),
+                'quantity' => 1,
+            ]);
+        }
+
+        return $shop;
+    }
+}


### PR DESCRIPTION
Closes #6

## Acceptance Criteria
- [x] Free plan user -> `/reports` redirects to `/billing` with upgrade message
- [x] Pro plan user -> `/reports` loads
- [x] Trial user -> `/reports` loads (treated as Pro)
- [x] Super admin -> `/reports` loads regardless of plan
- [x] Each Pro-gated route has a test
- [x] `BillingService::canAccess` switch handles every feature being gated (extend if needed; do NOT add silent default-true)

## Test Output
```text
$ php artisan test tests/Feature/PlanGatingTest.php tests/Feature/FreePlanAccessTest.php tests/Feature/RbacRouteAccessTest.php

   PASS  Tests\Feature\PlanGatingTest
  ✓ free plan blocked from reports                                       0.24s
  ✓ pro plan allowed to reports                                          0.07s
  ✓ trial user treated as pro                                            0.01s
  ✓ super admin bypasses plan gating                                     0.02s
  ✓ billing route remains accessible to free users                       0.02s
  ✓ free plan blocked from reports export                                0.01s
  ✓ pro plan allowed to reports export                                   0.01s
  ✓ free plan blocked from menu engineering                              0.01s
  ✓ pro plan allowed to menu engineering                                 0.02s
  ✓ trial user allowed to menu engineering                               0.01s
  ✓ free plan blocked from pricing rules                                 0.01s
  ✓ pro plan allowed to pricing rules                                    0.02s
  ✓ trial user allowed to pricing rules                                  0.01s
  ✓ billing service handles every gated feature                          0.01s

   PASS  Tests\Feature\FreePlanAccessTest
  ✓ free plan admin can access kds                                       0.02s
  ✓ free plan admin can access products                                  0.02s
  ✓ free plan admin can access menu builder                              0.02s
  ✓ free plan admin can access settings                                  0.02s
  ✓ free plan admin can access pos                                       0.02s
  ✓ free plan manager can access kds and catalog                         0.02s
  ✓ free plan kitchen can access kds                                     0.01s
  ✓ expired subscription shop is redirected to billing                   0.01s

   PASS  Tests\Feature\RbacRouteAccessTest
  ✓ server is blocked from manager and kitchen routes                    0.03s
  ✓ kitchen is blocked from pos and admin routes                         0.01s
  ✓ manager can access pos kds and admin modules                         0.03s
  ✓ admin can access pos kds and admin modules                           0.04s

  Tests:    26 passed (55 assertions)
  Duration: 0.79s
```

```text
$ ./vendor/bin/pint

  ............................................................................
  ............................................................................
  ............................................................................
  ..................................................

  ──────────────────────────────────────────────────────────────────── Laravel
    PASS   ......................................................... 278 files
```

```text
$ composer test

   PASS  Tests\Feature\PlanGatingTest
  ✓ free plan blocked from reports                                       0.01s
  ✓ pro plan allowed to reports                                          0.02s
  ✓ trial user treated as pro                                            0.02s
  ✓ super admin bypasses plan gating                                     0.02s
  ✓ billing route remains accessible to free users                       0.01s
  ✓ free plan blocked from reports export                                0.01s
  ✓ pro plan allowed to reports export                                   0.01s
  ✓ free plan blocked from menu engineering                              0.01s
  ✓ pro plan allowed to menu engineering                                 0.02s
  ✓ trial user allowed to menu engineering                               0.02s
  ✓ free plan blocked from pricing rules                                 0.01s
  ✓ pro plan allowed to pricing rules                                    0.02s
  ✓ trial user allowed to pricing rules                                  0.02s
  ✓ billing service handles every gated feature                          0.01s

  Tests:    298 passed (814 assertions)
  Duration: 11.16s
```

## Decisions
- Added `EnsurePlanFeature` as the `plan:feature_name` middleware and kept it in addition to `subscribed`.
- Applied `plan:reports` to `/reports` and `/reports/export`.
- `menu-engineering` and `pricing-rules` were not explicit in `config/billing.php`, so I added `Menu Engineering` and `Pricing Rules` to the Pro feature list and gated them as `plan:menu_engineering` and `plan:pricing_rules`.
- Changed `BillingService::canAccess` unknown-feature behavior from default-true to default-false so new gates must be explicitly handled.
- Preserved free-plan access to POS, KDS, products, menu builder, modifiers, settings, and `/billing`.
