### PR TITLE
Fix guest menu orderability validation

### DIFF
--- a/bite/app/Livewire/GuestMenu.php
+++ b/bite/app/Livewire/GuestMenu.php
@@ -7,6 +7,7 @@ use App\Models\Order;
 use App\Models\OrderItem;
 use App\Models\OrderItemModifier;
 use App\Models\PricingRule;
+use App\Models\Product;
 use App\Models\Shop;
 use App\Notifications\NewOrderNotification;
 use App\Services\LoyaltyService;
@@ -487,7 +488,7 @@ class GuestMenu extends Component
 
         $product = $this->shop->products()
             ->with('modifierGroups.options')
-            ->where('is_available', true)
+            ->orderable()
             ->find($productId);
 
         if (! $product) {
@@ -504,19 +505,14 @@ class GuestMenu extends Component
             return;
         }
 
-        if ($product->modifierGroups->isNotEmpty()) {
-            $selectedByGroup = $this->normalizeModifierGroups($this->selectedModifiers);
+        $selectedByGroup = $this->normalizeModifierGroups($this->selectedModifiers);
+        if ($product->modifierGroups->isNotEmpty() || ! empty($selectedByGroup)) {
+            $modifierError = $this->validateSelectedModifierGroups($product, $selectedByGroup);
+            if ($modifierError) {
+                $this->modifierError = $modifierError;
+                $this->showModifierModal = true;
 
-            foreach ($product->modifierGroups as $group) {
-                $selected = $selectedByGroup[$group->id] ?? [];
-                $count = count($selected);
-
-                if ($group->min_selection > 0 && $count < $group->min_selection) {
-                    $this->modifierError = __('guest.select_at_least', ['count' => $group->min_selection, 'group' => $group->translated('name')]);
-                    $this->showModifierModal = true;
-
-                    return;
-                }
+                return;
             }
         }
 
@@ -652,7 +648,7 @@ class GuestMenu extends Component
         $productIds = collect($cartItems)->pluck('id')->unique()->toArray();
         $products = $this->shop->products()
             ->with('modifierGroups.options')
-            ->where('is_available', true)
+            ->orderable()
             ->whereIn('id', $productIds)
             ->get()
             ->keyBy('id');
@@ -722,6 +718,14 @@ class GuestMenu extends Component
             $modifiersData = [];
 
             $modifierIds = $this->normalizeModifierIds($item['selectedModifiers'] ?? []);
+            $modifierError = $this->validateCartModifierIds($product, $modifierIds);
+            if ($modifierError) {
+                $this->orderError = $modifierError;
+                $this->showReviewModal = true;
+
+                return;
+            }
+
             $validOptions = $this->getValidModifierOptions($product, $modifierIds);
 
             foreach ($validOptions as $opt) {
@@ -877,8 +881,7 @@ class GuestMenu extends Component
         $products = $this->shop->products()
             ->with('modifierGroups.options')
             ->whereIn('id', $productIds)
-            ->where('is_visible', true)
-            ->where('is_available', true)
+            ->orderable()
             ->get()
             ->keyBy('id');
 
@@ -980,6 +983,103 @@ class GuestMenu extends Component
             ->whereIn('id', $modifierIds);
     }
 
+    protected function validateSelectedModifierGroups(Product $product, array $selectedByGroup): ?string
+    {
+        $groups = $product->modifierGroups->keyBy('id');
+
+        foreach ($selectedByGroup as $groupId => $selectedIds) {
+            $group = $groups->get((int) $groupId);
+            if (! $group) {
+                return __('guest.invalid_modifier_selection');
+            }
+
+            $selectedIds = $this->normalizeModifierIds($selectedIds);
+            if ($this->hasDuplicateModifierIds($selectedIds)) {
+                return __('guest.invalid_modifier_selection');
+            }
+
+            $allowedIds = $group->options
+                ->pluck('id')
+                ->map(fn ($id) => (int) $id)
+                ->all();
+
+            if (collect($selectedIds)->diff($allowedIds)->isNotEmpty()) {
+                return __('guest.invalid_modifier_selection');
+            }
+        }
+
+        foreach ($groups as $group) {
+            $selectedIds = $this->normalizeModifierIds($selectedByGroup[$group->id] ?? []);
+            $count = count($selectedIds);
+
+            if ($group->min_selection > 0 && $count < $group->min_selection) {
+                return __('guest.select_at_least', [
+                    'count' => $group->min_selection,
+                    'group' => $group->translated('name'),
+                ]);
+            }
+
+            if ($group->max_selection > 0 && $count > $group->max_selection) {
+                return __('guest.select_at_most', [
+                    'count' => $group->max_selection,
+                    'group' => $group->translated('name'),
+                ]);
+            }
+        }
+
+        return null;
+    }
+
+    protected function validateCartModifierIds(Product $product, array $modifierIds): ?string
+    {
+        if ($this->hasDuplicateModifierIds($modifierIds)) {
+            return __('guest.invalid_modifier_selection');
+        }
+
+        $groups = $product->modifierGroups;
+        $allowedIds = $groups
+            ->pluck('options')
+            ->flatten()
+            ->pluck('id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+
+        if (collect($modifierIds)->diff($allowedIds)->isNotEmpty()) {
+            return __('guest.invalid_modifier_selection');
+        }
+
+        foreach ($groups as $group) {
+            $groupOptionIds = $group->options
+                ->pluck('id')
+                ->map(fn ($id) => (int) $id)
+                ->all();
+            $count = collect($modifierIds)
+                ->intersect($groupOptionIds)
+                ->count();
+
+            if ($group->min_selection > 0 && $count < $group->min_selection) {
+                return __('guest.select_at_least', [
+                    'count' => $group->min_selection,
+                    'group' => $group->translated('name'),
+                ]);
+            }
+
+            if ($group->max_selection > 0 && $count > $group->max_selection) {
+                return __('guest.select_at_most', [
+                    'count' => $group->max_selection,
+                    'group' => $group->translated('name'),
+                ]);
+            }
+        }
+
+        return null;
+    }
+
+    protected function hasDuplicateModifierIds(array $modifierIds): bool
+    {
+        return count($modifierIds) !== count(array_unique($modifierIds));
+    }
+
     /**
      * Sum price adjustments for valid modifiers on a product.
      */
@@ -1040,7 +1140,7 @@ class GuestMenu extends Component
     {
         $categories = $this->shop->categories()
             ->with(['products' => function ($query) {
-                $query->where('is_visible', true)
+                $query->visible()
                     ->with('modifierGroups.options')
                     ->orderBy('sort_order');
             }])

--- a/bite/app/Models/Product.php
+++ b/bite/app/Models/Product.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Traits\HasTranslations;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
@@ -47,6 +48,17 @@ class Product extends Model
         }
 
         return round((float) ($this->price - $this->discount_value), 3);
+    }
+
+    public function scopeVisible(Builder $query): Builder
+    {
+        return $query->where('is_visible', true);
+    }
+
+    public function scopeOrderable(Builder $query): Builder
+    {
+        return $query->visible()
+            ->where('is_available', true);
     }
 
     public function shop()

--- a/bite/lang/ar/guest.php
+++ b/bite/lang/ar/guest.php
@@ -36,6 +36,8 @@ return [
     'optional' => 'اختياري',
     'add_for' => 'أضف بـ :price',
     'select_at_least' => 'اختر على الأقل :count خيار(ات) لـ :group.',
+    'select_at_most' => 'اختر كحد أقصى :count خيار(ات) لـ :group.',
+    'invalid_modifier_selection' => 'اختيار الإضافات غير صحيح.',
     'base_price' => 'أساسي',
 
     // Loyalty

--- a/bite/lang/en/guest.php
+++ b/bite/lang/en/guest.php
@@ -36,6 +36,8 @@ return [
     'optional' => 'Optional',
     'add_for' => 'Add for :price',
     'select_at_least' => 'Select at least :count option(s) for :group.',
+    'select_at_most' => 'Select at most :count option(s) for :group.',
+    'invalid_modifier_selection' => 'Invalid modifier selection.',
     'base_price' => 'Base',
 
     // Loyalty

--- a/bite/tests/Feature/GuestMenuValidationTest.php
+++ b/bite/tests/Feature/GuestMenuValidationTest.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\GuestMenu;
+use App\Models\Category;
+use App\Models\ModifierGroup;
+use App\Models\ModifierOption;
+use App\Models\Product;
+use App\Models\Shop;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class GuestMenuValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cannot_add_hidden_product_to_cart(): void
+    {
+        [$shop, $category] = $this->createMenu();
+        $product = $this->createProduct($shop, $category, [
+            'name_en' => 'Staff Meal',
+            'is_available' => true,
+            'is_visible' => false,
+        ]);
+
+        Livewire::test(GuestMenu::class, ['shop' => $shop])
+            ->call('addToCart', $product->id)
+            ->assertSet('cart', [])
+            ->assertSet('modifierError', null)
+            ->assertSet('orderError', null);
+    }
+
+    public function test_cannot_add_unavailable_product_to_cart(): void
+    {
+        [$shop, $category] = $this->createMenu();
+        $product = $this->createProduct($shop, $category, [
+            'name_en' => 'Sold Out Roll',
+            'is_available' => false,
+            'is_visible' => true,
+        ]);
+
+        Livewire::test(GuestMenu::class, ['shop' => $shop])
+            ->call('addToCart', $product->id)
+            ->assertSet('cart', []);
+    }
+
+    public function test_visible_unavailable_product_still_appears_in_menu_render(): void
+    {
+        [$shop, $category] = $this->createMenu();
+        $this->createProduct($shop, $category, [
+            'name_en' => 'Sold Out Roll',
+            'is_available' => false,
+            'is_visible' => true,
+        ]);
+
+        Livewire::test(GuestMenu::class, ['shop' => $shop])
+            ->assertSee('Sold Out Roll')
+            ->assertSee(__('guest.sold_out'));
+    }
+
+    public function test_max_selection_enforced(): void
+    {
+        $fixture = $this->createProductWithModifierGroup([
+            'min_selection' => 0,
+            'max_selection' => 1,
+        ]);
+
+        $component = Livewire::test(GuestMenu::class, ['shop' => $fixture['shop']])
+            ->call('addToCart', $fixture['product']->id)
+            ->set('selectedModifiers', [
+                $fixture['group']->id => [
+                    (string) $fixture['optionA']->id,
+                    (string) $fixture['optionB']->id,
+                ],
+            ])
+            ->call('addToCart', $fixture['product']->id)
+            ->assertSet('cart', [])
+            ->assertSet('showModifierModal', true);
+
+        $this->assertSame(
+            __('guest.select_at_most', ['count' => 1, 'group' => 'Size']),
+            $component->get('modifierError')
+        );
+    }
+
+    public function test_invalid_modifier_option_id_rejected(): void
+    {
+        $fixture = $this->createProductWithModifierGroup();
+
+        $component = Livewire::test(GuestMenu::class, ['shop' => $fixture['shop']])
+            ->call('addToCart', $fixture['product']->id)
+            ->set('selectedModifiers', [
+                $fixture['group']->id => ['999999'],
+            ])
+            ->call('addToCart', $fixture['product']->id)
+            ->assertSet('cart', [])
+            ->assertSet('showModifierModal', true);
+
+        $this->assertSame(__('guest.invalid_modifier_selection'), $component->get('modifierError'));
+    }
+
+    public function test_modifier_option_from_other_group_rejected(): void
+    {
+        $fixture = $this->createProductWithModifierGroup();
+        $otherGroup = ModifierGroup::create([
+            'shop_id' => $fixture['shop']->id,
+            'name_en' => 'Sauce',
+            'min_selection' => 0,
+            'max_selection' => 1,
+        ]);
+        $otherOption = ModifierOption::create([
+            'modifier_group_id' => $otherGroup->id,
+            'name_en' => 'Garlic',
+            'price_adjustment' => 0.100,
+        ]);
+
+        $component = Livewire::test(GuestMenu::class, ['shop' => $fixture['shop']])
+            ->call('addToCart', $fixture['product']->id)
+            ->set('selectedModifiers', [
+                $fixture['group']->id => [(string) $otherOption->id],
+            ])
+            ->call('addToCart', $fixture['product']->id)
+            ->assertSet('cart', [])
+            ->assertSet('showModifierModal', true);
+
+        $this->assertSame(__('guest.invalid_modifier_selection'), $component->get('modifierError'));
+    }
+
+    public function test_submit_order_revalidates_against_orderable_scope(): void
+    {
+        [$shop, $category] = $this->createMenu();
+        $product = $this->createProduct($shop, $category, [
+            'name_en' => 'Karak',
+            'is_available' => true,
+            'is_visible' => true,
+        ]);
+
+        $component = Livewire::test(GuestMenu::class, ['shop' => $shop])
+            ->call('addToCart', $product->id);
+
+        $product->update(['is_visible' => false]);
+
+        $component->call('submitOrder')
+            ->assertSet('showReviewModal', true)
+            ->assertNotSet('orderError', null);
+
+        $this->assertDatabaseCount('orders', 0);
+    }
+
+    private function createMenu(): array
+    {
+        $shop = Shop::create([
+            'name' => 'Bite',
+            'slug' => 'bite',
+        ]);
+        $category = Category::create([
+            'shop_id' => $shop->id,
+            'name_en' => 'Cafe',
+        ]);
+
+        return [$shop, $category];
+    }
+
+    private function createProduct(Shop $shop, Category $category, array $attributes = []): Product
+    {
+        return Product::forceCreate(array_merge([
+            'shop_id' => $shop->id,
+            'category_id' => $category->id,
+            'name_en' => 'Karak',
+            'price' => 1.000,
+            'is_available' => true,
+            'is_visible' => true,
+        ], $attributes));
+    }
+
+    private function createProductWithModifierGroup(array $groupAttributes = []): array
+    {
+        [$shop, $category] = $this->createMenu();
+        $product = $this->createProduct($shop, $category);
+
+        $group = ModifierGroup::create(array_merge([
+            'shop_id' => $shop->id,
+            'name_en' => 'Size',
+            'min_selection' => 0,
+            'max_selection' => 2,
+        ], $groupAttributes));
+        $optionA = ModifierOption::create([
+            'modifier_group_id' => $group->id,
+            'name_en' => 'Small',
+            'price_adjustment' => 0,
+        ]);
+        $optionB = ModifierOption::create([
+            'modifier_group_id' => $group->id,
+            'name_en' => 'Large',
+            'price_adjustment' => 0.200,
+        ]);
+
+        $product->modifierGroups()->attach($group->id);
+
+        return compact('shop', 'category', 'product', 'group', 'optionA', 'optionB');
+    }
+}


### PR DESCRIPTION
Closes #7

## Acceptance Criteria
- [x] Add `Product::scopeVisible()` and `Product::scopeOrderable()`. Use Visible in menu render. Use Orderable in `addToCart` and `submitOrder`. The actual bug being fixed: `addToCart` and `submitOrder` are missing the `is_visible` check, so hidden-but-available products can be added to cart by ID via crafted Livewire calls. `is_available` (sold out) is already checked correctly.
- [x] Crafted Livewire `addToCart($hiddenProductId)` -> no cart change, no error leak.
- [x] Selecting `> max_selection` options -> error message, no cart change.
- [x] Selecting an option ID from another group / fake ID -> error, no cart change.
- [x] `submitOrder` re-validates with same scope. If anything changed mid-session, order rejected.
- [x] Existing happy-path tests still pass.
- [x] New test covers each bypass scenario.

## Test Coverage
- [x] `test_cannot_add_hidden_product_to_cart`
- [x] `test_cannot_add_unavailable_product_to_cart`
- [x] `test_visible_unavailable_product_still_appears_in_menu_render`
- [x] `test_max_selection_enforced`
- [x] `test_invalid_modifier_option_id_rejected`
- [x] `test_modifier_option_from_other_group_rejected`
- [x] `test_submit_order_revalidates_against_orderable_scope`

## Test Output

```text
$ ./vendor/bin/pint

  ──────────────────────────────────────────────────────────────────── Laravel
    PASS   ......................................................... 279 files
```

```text
$ composer test

  Tests:    305 passed (832 assertions)
  Duration: 11.02s
```

## Decisions
Original ticket assumed menu render filters by both `is_visible` and `is_available`. Verified that is incorrect: render intentionally shows visible-but-unavailable products as sold out. Implemented two scopes (`visible` for render, `orderable` for cart/order actions) and confirmed the actual security gap was `addToCart`/`submitOrder` missing the `is_visible` check.
